### PR TITLE
Add the missing "System" category required by FDO menu specification

### DIFF
--- a/tilda.desktop.in
+++ b/tilda.desktop.in
@@ -5,4 +5,4 @@ Exec=@BINDIR@/tilda
 Icon=@PIXMAPSDIR@/tilda.png
 Terminal=false
 Type=Application
-Categories=GNOME;GTK;Application;Utility;TerminalEmulator;
+Categories=GNOME;GTK;Application;System;Utility;TerminalEmulator;


### PR DESCRIPTION
Running "desktop-file-validte tilda.desktop" shows following warnings:

tilda.desktop: error: (will be fatal in the future): value "TerminalEmulator" in key "Categories" in group "Desktop Entry" requires another category to be present among the following categories: System

FDO menu specification[1] suggests(or requires?) "System" to be also used when
"TerminalEmualtor" is used. That is what xterm and konsole do in their
.desktop files.

[1] http://standards.freedesktop.org/menu-spec/latest/apa.html
