### PR TITLE
Fix glib/gtk/gdk header includes

### DIFF
--- a/README
+++ b/README
@@ -76,13 +76,17 @@ will be able to grab it for you.
 
 Files that Tilda creates
 ================================================================================
-On its first run, Tilda will attempt to create the directory ~/.tilda. Inside of
-this directory, it will create another directory ~/.tilda/locks. Inside the
-~/.tilda/locks directory, Tilda will create a file each time it starts, in order
-to keep track of how many instances are running. The naming of lock files follow
-the format "lock_$PID_$INSTANCE". Configuration files are stored inside
-~/.tilda, and have the format "config_$INSTANCE".
-
+Tilda now adheres to the XDG Base Directory Specification and creates its files
+in the $XDG_CONFIG_HOME and $XDG_CACHE_HOME folders which normally default to
+~/.config/ and ~/.cache/. Tilda will create a lock file in the cache directory
+each time it starts, to keep track of how many instances are running:
+    ~/.cache/tilda/locks/lock_$PID_$INSTANCE
+Tilda will also create the config files in:
+    ~/.config/tilda/config_$INSTANCE
+where $INSTANCE is the number of how many instances are running and
+$PID the process id. If you have been using the old version of tilda before,
+there is a migration function, that will automatically move the files at the
+old location ~/.tilda/ to the XDG folders for you.
 
 Getting more help
 ================================================================================

--- a/src/eggaccelerators.h
+++ b/src/eggaccelerators.h
@@ -21,7 +21,7 @@
 #ifndef __EGG_ACCELERATORS_H__
 #define __EGG_ACCELERATORS_H__
 
-#include <gtk/gtkaccelgroup.h>
+#include <gtk/gtk.h>
 #include <gdk/gdk.h>
 
 G_BEGIN_DECLS

--- a/src/key_grabber.c
+++ b/src/key_grabber.c
@@ -31,7 +31,7 @@
 #include <X11/keysym.h>
 #include <X11/Xutil.h>
 #include <X11/cursorfont.h>
-#include <gtk/gtkmain.h>
+#include <gtk/gtk.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/tomboykeybinder.c
+++ b/src/tomboykeybinder.c
@@ -1,7 +1,6 @@
 #include <string.h>
 
 #include <gdk/gdk.h>
-#include <gdk/gdkwindow.h>
 #include <gdk/gdkx.h>
 #include <X11/Xlib.h>
 

--- a/src/tomboykeybinder.h
+++ b/src/tomboykeybinder.h
@@ -2,7 +2,7 @@
 #ifndef __TOMBOY_KEY_BINDER_H__
 #define __TOMBOY_KEY_BINDER_H__
 
-#include <glib/gtypes.h>
+#include <glib.h>
 
 G_BEGIN_DECLS
 


### PR DESCRIPTION
Hi Tristan,

this should fix the compile problem for glib 2.32 as mentioned in Issue #3.

Regards
Lanoxx
