### PR TITLE
Add option to respawn terminal when last one was closed

### DIFF
--- a/src/configsys.c
+++ b/src/configsys.c
@@ -68,6 +68,7 @@ static cfg_opt_t config_opts[] = {
     CFG_INT("animation_orientation", 0, CFGF_NONE),
     CFG_INT("timer_resolution", 1000, CFGF_NONE),
     CFG_INT("auto_hide_time", 2000, CFGF_NONE),
+    CFG_INT("on_last_terminal_exit", 0, CFGF_NONE),
     CFG_INT("palette_scheme", 0, CFGF_NONE),
  
 /* int list */

--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -457,7 +457,7 @@ static void child_exited_cb (GtkWidget *widget, gpointer data)
     switch (config_getint ("command_exit"))
     {
         case EXIT_TERMINAL:
-            tilda_window_close_tab (tt->tw, index);
+            tilda_window_close_tab (tt->tw, index, FALSE);
             break;
         case RESTART_COMMAND:
             vte_terminal_feed (VTE_TERMINAL(tt->vte_term), "\r\n\r\n", 4);

--- a/src/tilda_window.h
+++ b/src/tilda_window.h
@@ -64,7 +64,7 @@ struct tilda_window_
 enum notebook_tab_positions { NB_TOP, NB_BOTTOM, NB_LEFT, NB_RIGHT };
 
 gint tilda_window_add_tab (tilda_window *tw);
-gint tilda_window_close_tab (tilda_window *tw, gint tab_position);
+gint tilda_window_close_tab (tilda_window *tw, gint tab_position, gboolean force_exit);
 tilda_window *tilda_window_init (const gchar *config_file, const gint instance);
 gint tilda_window_free (tilda_window *tw);
 gint toggle_fullscreen_cb (tilda_window *tw);

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -736,6 +736,13 @@ static void combo_command_exit_changed_cb (GtkWidget *w)
     config_setint ("command_exit", status);
 }
 
+static void combo_on_last_terminal_exit_changed_cb (GtkWidget *w)
+{
+    const gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
+
+    config_setint ("on_last_terminal_exit", status);
+}
+
 static void entry_web_browser_changed (GtkWidget *w)
 {
     const gchar *web_browser = gtk_entry_get_text (GTK_ENTRY(w));
@@ -1525,6 +1532,7 @@ static void set_wizard_state_from_config ()
     CHECK_BUTTON ("check_run_custom_command", "run_command");
     TEXT_ENTRY ("entry_custom_command", "command");
     COMBO_BOX ("combo_command_exit", "command_exit");
+    COMBO_BOX ("combo_on_last_terminal_exit", "on_last_terminal_exit");
     SET_SENSITIVE_BY_CONFIG_BOOL ("entry_custom_command","run_command");
     SET_SENSITIVE_BY_CONFIG_BOOL ("label_custom_command", "run_command");
 
@@ -1657,6 +1665,7 @@ static void connect_wizard_signals ()
 
     CONNECT_SIGNAL ("check_run_custom_command","toggled",check_run_custom_command_toggled_cb);
     CONNECT_SIGNAL ("combo_command_exit","changed",combo_command_exit_changed_cb);
+    CONNECT_SIGNAL ("combo_on_last_terminal_exit","changed",combo_on_last_terminal_exit_changed_cb);
 
     CONNECT_SIGNAL ("entry_web_browser","changed",entry_web_browser_changed);
     CONNECT_SIGNAL ("entry_word_chars","changed",entry_word_chars_changed);

--- a/tilda.glade
+++ b/tilda.glade
@@ -20,7 +20,7 @@
             <child>
               <widget class="GtkTable" id="table_general">
                 <property name="visible">True</property>
-                <property name="n_rows">4</property>
+                <property name="n_rows">5</property>
                 <child>
                   <widget class="GtkFrame" id="frame_window_auto_hide">
                     <property name="visible">True</property>
@@ -98,6 +98,65 @@
                   <packing>
                     <property name="top_attach">3</property>
                     <property name="bottom_attach">4</property>
+                    <property name="y_options"></property>
+                    <property name="x_padding">4</property>
+                    <property name="y_padding">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkFrame" id="frame_program_exit">
+                    <property name="visible">True</property>
+                    <property name="label_xalign">0</property>
+                    <child>
+                      <widget class="GtkAlignment" id="alignment35">
+                        <property name="visible">True</property>
+                        <property name="left_padding">12</property>
+                        <child>
+                          <widget class="GtkTable" id="table27">
+                            <property name="visible">True</property>
+                            <property name="n_columns">2</property>
+                            <child>
+                              <widget class="GtkComboBox" id="combo_on_last_terminal_exit">
+                                <property name="visible">True</property>
+                                <property name="items" translatable="yes">Close Tilda
+Open a new terminal
+Open a new terminal and hide</property>
+                              </widget>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="right_attach">2</property>
+                                <property name="x_padding">4</property>
+                                <property name="y_padding">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <widget class="GtkLabel" id="label_on_last_terminal_exit">
+                                <property name="visible">True</property>
+                                <property name="label" translatable="yes">When Last Terminal is Closed:</property>
+                              </widget>
+                              <packing>
+                                <property name="x_padding">4</property>
+                                <property name="y_padding">4</property>
+                              </packing>
+                            </child>
+                          </widget>
+                        </child>
+                      </widget>
+                    </child>
+                    <child>
+                      <widget class="GtkLabel" id="label23">
+                        <property name="visible">True</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Program exit&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                      </widget>
+                      <packing>
+                        <property name="type">label_item</property>
+                      </packing>
+                    </child>
+                  </widget>
+                  <packing>
+                    <property name="top_attach">4</property>
+                    <property name="bottom_attach">5</property>
                     <property name="y_options"></property>
                     <property name="x_padding">4</property>
                     <property name="y_padding">4</property>


### PR DESCRIPTION
Hi Tristan,

I've implemented a feature that I found missing after switching from Yakuake to Tilda.

The user can now select what should happen when the last terminal is closed: exit Tilda, respawn the terminal, or respawn the terminal and hide Tilda. The first option was the behaviour until now and remains the default. With the two new options Tilda will always have a terminal ready for you, even if you accidentally exit the only session. It's still possible to quit Tilda from the context menu.

I'd be glad if this feature could be incorporated. Cheers,
  Felix
